### PR TITLE
Use native `Element.closest()` method

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
-    "closest": "^0.0.1",
     "react": "^16.13.0",
     "react-dom": "^16.13.0"
   },

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import ReactDOM from 'react-dom';
-import closest from 'closest';
 
 interface IMouseProps {
     /**
@@ -234,7 +233,7 @@ export default class IMouse extends React.Component<IMouseProps, IMouseState> {
 
     handleMouseOver = (e: MouseEvent) => {
         const { target } = e;
-        const hoverTarget = closest(target, this.props.hoverSelector, true);
+        const hoverTarget = target.closest(this.props.hoverSelector);
         if (this.state.hoverTarget !== hoverTarget) {
             if (this.setSteadyHoverTimeout) {
                 clearTimeout(this.setSteadyHoverTimeout);


### PR DESCRIPTION
`Element.closest()` is supported in all evergreen browsers (except IE, but it is likely to be polyfilled as well if using React), see https://caniuse.com/#feat=element-closest.